### PR TITLE
init: Reboot to recovery after benchmark its finished

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -157,4 +157,4 @@ save_logs
 # To debug system load
 #htop
 
-reboot_end ''
+reboot_end recovery


### PR DESCRIPTION
Instead of keep rebooting and doing the benchmark again,just reboot to recovery to let us know the benchmark has finished