### PR TITLE
Change base_power calculation to prevent too low values

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -310,7 +310,7 @@ def init_power():
     thread = start_power_thread(sample_interval=POWER_SAMPLE_INTERVAL * 2)
     time.sleep(60)
     base_power_samples = stop_power_thread(thread)
-    base_power = min(base_power_samples)
+    base_power = statistics.median(base_power_samples)
     print(f"{base_power:.0f} mW")
     print()
 


### PR DESCRIPTION
The base_power is currently calculated as the minimum value of the power measurements. This value can sometimes be lower than the actual average base power draw, resulting in too low base_power and thus too high per-frequency power and too low efficiency results. This can be seen on some results already, especially the proposed results of the SM7325.
This patch changes the calculation of the base_power from being the smallest measurement (min) to the average measurement (median).
I've tested this on my Samsung Galaxy A5 (2017) and it worked fine for me.